### PR TITLE
change file permissions, start as nobody

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,4 +25,9 @@ COPY start.sh .
 COPY beaverhabits ./beaverhabits
 COPY statics ./statics
 
+RUN chmod -R g+w /app && \
+    chown -R nobody /app
+
+USER nobody
+
 CMD ["sh", "start.sh", "prd"]

--- a/Dockerfile.buildkit.arm32
+++ b/Dockerfile.buildkit.arm32
@@ -32,4 +32,9 @@ COPY start.sh .
 COPY beaverhabits ./beaverhabits
 COPY statics ./statics
 
+RUN chmod -R g+w /app && \
+    chown -R nobody /app
+
+USER nobody
+
 CMD ["sh", "start.sh", "prd"]

--- a/Dockerfile.nobuildkit.arm32
+++ b/Dockerfile.nobuildkit.arm32
@@ -33,4 +33,9 @@ COPY start.sh .
 COPY beaverhabits ./beaverhabits
 COPY statics ./statics
 
+RUN chmod -R g+w /app && \
+    chown -R nobody /app
+
+USER nobody
+
 CMD ["sh", "start.sh", "prd"]


### PR DESCRIPTION
These change increase the security and make it OpenShift compatible.

* Run container per default not as root but as user nobody
* Change permissions so it can be run with any UID.

I tested it locally and did a smoke test on OpenShift. I could build all Dockerfiles, but had no arm32 machine to run all.