### PR TITLE
update readme for rootles image

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ docker run -d --name beaverhabits \
   -v /path/to/host/directory:/app/.user/ \
   -p 8080:8080 \
   --restart unless-stopped \
+  -u $(id -u):$(id -g) \
   daya0576/beaverhabits:latest
 ```
 


### PR DESCRIPTION
This fix Issues mentioned here: https://github.com/daya0576/beaverhabits/issues/19, https://github.com/daya0576/beaverhabits/issues/21

The old image started by default as root, so it was always able to write to any filesystem. With the new configuration, it starts by default as user nobody, which doesn't have any permissions on the user's filesystem. With this change in the start command, the container gets started with uid:gid from the user starting the container, and so the permissions should match.