### PR TITLE
Add UMAMI_ANALYTICS_ID config option to allow custom umami tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ To avoid [permission issues](https://github.com/daya0576/beaverhabits/discussion
 | **TRUSTED_EMAIL_HEADER**(str) | Delegate authentication to an authenticating reverse proxy that passes in the user's details in HTTP headers, e.g. `Cf-Access-Authenticated-User-Email`. An existing account is required. |
 | **TRUSTED_LOCAL_EMAIL**(str) | Disables authentication entirely. A new account with the specified email will be created if it does not exist. |
 | **INDEX_HABIT_DATE_REVERSE**(bool) | Reverse the order of dates to display (default value is false). |
+| **UMAMI_ANALYTICS_ID**(str) | Umami analytics tracking id. If left empty (default) no tracking snippet will be injected. |
 
 ## Development
 

--- a/beaverhabits/configs.py
+++ b/beaverhabits/configs.py
@@ -57,6 +57,8 @@ class Settings(BaseSettings):
     INDEX_HABIT_DATE_COLUMNS: int = 5
     INDEX_HABIT_DATE_REVERSE: bool = False
 
+    UMAMI_ANALYTICS_ID: str = ''
+
     def is_dev(self):
         return self.ENV == "dev"
 

--- a/beaverhabits/frontend/layout.py
+++ b/beaverhabits/frontend/layout.py
@@ -53,12 +53,10 @@ def custom_header():
     ui.add_head_html(
         '<meta name="description" content="A self-hosted habit tracking app without "Goals"">'
     )
-
-
-def add_umami_headers():
-    ui.add_head_html(
-        '<script defer src="https://cloud.umami.is/script.js" data-website-id="246fa4ac-0f4f-464a-8a32-14c9f75fed77"></script>'
-    )
+    if settings.UMAMI_ANALYTICS_ID:
+        ui.add_head_html(
+            f'<script defer src="https://cloud.umami.is/script.js" data-website-id="{settings.UMAMI_ANALYTICS_ID}"></script>'
+        )
 
 
 def separator():
@@ -104,7 +102,6 @@ def layout(title: str | None = None, with_menu: bool = True):
     with ui.column() as c:
         # Standard headers
         custom_header()
-        add_umami_headers()
         pre_cache()
 
         # Center the content on small screens


### PR DESCRIPTION
This PR adds a new configuration option to allow users to specify their own custom analytics snippets to be included in the <head> section of the generated page.
