### PR TITLE
feat: enable selecting a self-hosted Umami Analytics instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ To avoid [permission issues](https://github.com/daya0576/beaverhabits/discussion
 | **TRUSTED_LOCAL_EMAIL**(str) | Disables login page entirely. A new account with the specified email will be created if it does not exist. |
 | **INDEX_HABIT_DATE_REVERSE**(bool) | Reverse the order of dates to display (default value is false). |
 | **UMAMI_ANALYTICS_ID**(str) | Umami analytics tracking id. If left empty (default) no tracking snippet will be injected. |
+| **UMAMI_SCRIPT_URL**(str) | Umami analytics tracking script url. If `UMAMI_ANALYTICS_ID` is left empty (default), no tracking snippet will be injected. The default value is `https://cloud.umami.is/script.js`. |
 | **DARK_MODE**(bool) | Default: `None` for "auto" mode.  |
 
 ## Development

--- a/beaverhabits/configs.py
+++ b/beaverhabits/configs.py
@@ -32,6 +32,7 @@ class Settings(BaseSettings):
     HIGHLIGHT_KEY: str = ""
     ADMIN_EMAIL: str = ""
     UMAMI_ANALYTICS_ID: str = ""
+    UMAMI_SCRIPT_URL: str = "https://cloud.umami.is/script.js"
     ENABLE_PLAN: bool = False
     MAX_HABIT_COUNT: int = 5
     PADDLE_SANDBOX: bool = True

--- a/beaverhabits/frontend/layout.py
+++ b/beaverhabits/frontend/layout.py
@@ -56,7 +56,7 @@ def custom_headers():
     # Analytics
     if settings.UMAMI_ANALYTICS_ID:
         ui.add_head_html(
-            f'<script defer src="https://cloud.umami.is/script.js" data-website-id="{settings.UMAMI_ANALYTICS_ID}"></script>'
+            f'<script defer src="{settings.UMAMI_SCRIPT_URL}" data-website-id="{settings.UMAMI_ANALYTICS_ID}"></script>'
         )
 
     # Long-press event


### PR DESCRIPTION
This PR adds the `UMAMI_SCRIPT_URL` environment variable.

Resolves #108