### PR TITLE
fix: streaks not visible in calendar heat maps when using light mode

### DIFF
--- a/beaverhabits/frontend/components.py
+++ b/beaverhabits/frontend/components.py
@@ -629,14 +629,20 @@ class CalendarCheckBox(ui.checkbox):
     def _icon_svg(self):
         unchecked_text_color = checked_text_color = "rgb(255,255,255)"
         unchecked_color, checked_color = "rgb(54,54,54)", icons.PRIMARY_COLOR
-        if CStatus.PERIOD_DONE in self.status:
-            # Normalization + Linear Interpolation
-            unchecked_color = "rgb(40,87,141)"
 
         dark = get_user_dark_mode()
         if dark == False:
             unchecked_color = "rgb(222,222,222)"
             unchecked_text_color = "rgb(100,100,100)"
+
+        if CStatus.PERIOD_DONE in self.status:
+            # Normalization + Linear Interpolation
+            if dark:
+                unchecked_color = "rgb(40,87,141)"
+            else:
+                # Interpolation with .25
+                unchecked_color = "rgb(201,213,226)"
+
 
         return (
             icons.SQUARE.format(


### PR DESCRIPTION
Previously, streaks were not visible in the calendar heat maps in light mode. This PR fixes the issue.

| Before | Now (fixed) |
|:---:|:---:|
| <img width="371" height="560" alt="Bildschirmfoto vom 2025-08-23 17-43-58" src="https://github.com/user-attachments/assets/88aef715-1874-4bbd-b654-47761b8c554e" /> | <img width="371" height="560" alt="Bildschirmfoto vom 2025-08-23 17-43-45" src="https://github.com/user-attachments/assets/bad563b1-b621-459a-964c-734b66c07fba" /> |
