### PR TITLE
feat: add configurable today alignment to specific day of week

### DIFF
--- a/beaverhabits/configs.py
+++ b/beaverhabits/configs.py
@@ -68,6 +68,8 @@ class Settings(BaseSettings):
 
     # Customization
     FIRST_DAY_OF_WEEK: int = calendar.MONDAY
+    # Set to 0-6 to align today to specific day of week, e.g., 0 for Monday
+    ALIGN_TODAY_TO_DAY_OF_WEEK: int | None = None
     ENABLE_IOS_STANDALONE: bool = True
     TAG_SELECTION_MODE: TagSelectionMode = TagSelectionMode.MULTI
     ENABLE_TAG_FILTERS: bool = True


### PR DESCRIPTION
Set to 0-6 to align today to specific day of week, e.g., 4 for Friday. This enables displaying a complete week (Monday-Sunday) even when current day is mid-week. 

@Joaopedrobs7 
close #123