### PR TITLE
fix: simplify login redirect and remove habit name saved notification

### DIFF
--- a/beaverhabits/frontend/components.py
+++ b/beaverhabits/frontend/components.py
@@ -400,8 +400,6 @@ class HabitNameInput(ui.input):
         if self.habit.tags:
             if self.refresh:
                 self.refresh()
-        
-        ui.notify("Habit name saved")
 
     def _validate(self, value: str) -> Optional[str]:
         if not value:

--- a/beaverhabits/routes/routes.py
+++ b/beaverhabits/routes/routes.py
@@ -308,7 +308,6 @@ async def get_note_image(image_id: str, user: User = Depends(current_active_user
     return StreamingResponse(io.BytesIO(img.blob), media_type="image/png")
 
 
-
 def init_gui_routes(fastapi_app: FastAPI):
     def handle_exception(exception: Exception):
         if isinstance(exception, HTTPException):
@@ -332,7 +331,7 @@ def init_gui_routes(fastapi_app: FastAPI):
         if response.status_code == 401:
             # root_path = request.scope["root_path"]
             # app.storage.user["referrer_path"] = request.url.path.removeprefix(root_path)
-            return RedirectResponse(request.url_for(login_page.__name__))
+            return RedirectResponse("/login")
 
         return response
 


### PR DESCRIPTION
## Summary

- Replace `url_for(login_page.__name__)` with hardcoded `"/login"` path in the 401 redirect handler for more reliable redirects
- Remove `ui.notify("Habit name saved")` toast notification that appeared after saving a habit name

## Test plan

- [ ] Verify unauthenticated requests redirect correctly to `/login`
- [ ] Verify habit name changes save without a toast notification appearing