### PR TITLE
feat: add completion status page

### DIFF
--- a/beaverhabits/frontend/chip_sets_page.py
+++ b/beaverhabits/frontend/chip_sets_page.py
@@ -1,0 +1,73 @@
+from nicegui import ui
+
+from beaverhabits import views
+from beaverhabits.app.db import User
+from beaverhabits.frontend.layout import layout
+
+
+def _mapping_to_chips(mapping: dict[str, str]) -> list[str]:
+    """Convert {"yes": "red"} to ["yes:red"]"""
+    return [f"{k}:{v}" for k, v in mapping.items()]
+
+
+def _chips_to_mapping(chips: list[str]) -> dict[str, str]:
+    """Convert ["yes:red"] to {"yes": "red"}"""
+    mapping = {}
+    for chip in chips:
+        if ":" in chip:
+            k, v = chip.split(":", 1)
+            if k.strip() and v.strip():
+                mapping[k.strip()] = v.strip()
+    return mapping
+
+
+async def chip_sets_page(user: User):
+    configs = await views.get_user_configs(user)
+    current_chips = configs.default_chips or []
+    current_mapping = configs.default_chips_mapping or {}
+
+    with layout():
+        with ui.column().classes("w-full max-w-[600px] px-4 gap-4"):
+            # Header
+            with ui.row().classes("w-full items-center justify-between"):
+                ui.label("Completion Status").classes("text-lg font-medium")
+                ui.link(
+                    "Docs ↗",
+                    "https://github.com/daya0576/beaverhabits/wiki/Daily-Notes-&-Descriptions#streak-customization",
+                    new_tab=True,
+                ).classes("text-sm opacity-50 no-underline hover:underline")
+
+            ui.separator().classes("opacity-30")
+
+            # Section 1: Default status
+            with ui.column().classes("w-full gap-1"):
+                ui.label("Default Status").classes("text-sm font-medium opacity-80")
+                ui.label(
+                    "Default status buttons shown in the note dialog (e.g. yes, no, skip)."
+                ).classes("text-xs opacity-50")
+                chips_input = ui.input_chips(
+                    "e.g. yes, no, skip",
+                    value=current_chips,
+                    new_value_mode="add-unique",
+                ).classes("w-full")
+
+            ui.separator().classes("opacity-30")
+
+            # Section 2: Custom status
+            with ui.column().classes("w-full gap-1"):
+                ui.label("Custom Status").classes("text-sm font-medium opacity-80")
+                ui.label(
+                    "Map a status to tags that are auto-appended to the note on click."
+                ).classes("text-xs opacity-50")
+                mapping_input = ui.input_chips(
+                    "e.g. skip:#amber #skip",
+                    value=_mapping_to_chips(current_mapping),
+                    new_value_mode="add-unique",
+                ).classes("w-full")
+
+            async def save_chips():
+                mapping = _chips_to_mapping(mapping_input.value)
+                await views.update_default_chips(user, chips_input.value, mapping)
+                ui.notify("Saved", color="positive")
+
+            ui.button("Save", on_click=save_chips).props("flat dense")

--- a/beaverhabits/frontend/layout.py
+++ b/beaverhabits/frontend/layout.py
@@ -175,10 +175,6 @@ def menu_component():
                 menu_icon_item("Stats", lambda: redirect("stats"))
                 separator()
 
-                # API Tokens
-                menu_icon_item("Tokens", lambda: redirect("tokens"))
-                separator()
-
         separator()
 
         # About page

--- a/beaverhabits/routes/routes.py
+++ b/beaverhabits/routes/routes.py
@@ -33,6 +33,7 @@ from beaverhabits.frontend.import_page import import_ui_page
 from beaverhabits.frontend.index_page import index_page_ui
 from beaverhabits.frontend.layout import custom_headers, redirect
 from beaverhabits.frontend.order_page import order_page_ui
+from beaverhabits.frontend.chip_sets_page import chip_sets_page
 from beaverhabits.frontend.settings_page import settings_page
 from beaverhabits.frontend.stats_page import stats_page_ui
 from beaverhabits.frontend.streaks import heatmap_page
@@ -179,6 +180,11 @@ async def gui_settings(user: User = Depends(current_active_user)) -> None:
 @ui.page("/gui/tokens")
 async def gui_tokens(user: User = Depends(current_active_user)) -> None:
     await tokens_page(user)
+
+
+@ui.page("/gui/chip-sets")
+async def gui_chip_sets(user: User = Depends(current_active_user)) -> None:
+    await chip_sets_page(user)
 
 
 @ui.page("/login")

--- a/beaverhabits/storage/dict.py
+++ b/beaverhabits/storage/dict.py
@@ -162,12 +162,10 @@ class DictHabit(Habit[DictRecord], DictStorage):
 
     @property
     def chips(self) -> list[str]:
-        return self.data.get("chips", []) or ["yes", "no"]
+        return self.data.get("chips", [])
 
     @chips.setter
     def chips(self, value: list[str]) -> None:
-        if not value:
-            return
         self.data["chips"] = value
 
     @property

--- a/beaverhabits/views.py
+++ b/beaverhabits/views.py
@@ -247,12 +247,16 @@ async def reset_password(user: User, password: str) -> None:
 @dataclass
 class UserConfigs:
     custom_css: str | None = None
+    default_chips: list[str] | None = None
+    default_chips_mapping: dict[str, str] | None = None
 
 
 async def get_user_configs(user: User) -> UserConfigs:
     configs = await crud.get_user_configs(user) or {}
     return UserConfigs(
         custom_css=configs.get("css", None),
+        default_chips=configs.get("default_chips", None),
+        default_chips_mapping=configs.get("default_chips_mapping", None),
     )
 
 
@@ -261,6 +265,8 @@ async def cache_user_configs(user: User) -> None:
     app.storage.user.update(
         {
             "custom_css": configs.custom_css or "",
+            "default_chips": configs.default_chips or [],
+            "default_chips_mapping": configs.default_chips_mapping or {},
         }
     )
 
@@ -272,6 +278,21 @@ async def update_custom_css(user: User, css: str) -> None:
         user,
         {
             "css": css,
+        },
+    )
+
+
+async def update_default_chips(
+    user: User, chips: list[str], mapping: dict[str, str]
+) -> None:
+    app.storage.user["default_chips"] = chips
+    app.storage.user["default_chips_mapping"] = mapping
+
+    await crud.update_user_configs(
+        user,
+        {
+            "default_chips": chips,
+            "default_chips_mapping": mapping,
         },
     )
 


### PR DESCRIPTION
## Summary

Add a dedicated page for configuring default and custom completion status options.

### Changes
- **New page**: `/gui/chip-sets` for managing completion status configuration
  - **Default Status**: fallback status buttons shown in the note dialog (e.g. yes, no, skip)
  - **Custom Status**: map a status to tags that are auto-appended to the note on click (e.g. `skip:#amber #skip`)
- **Habit edit dialog**: show default chips as fallback when habit has no custom chips; add icon link to chip-sets page
- **Note dialog**: apply chips mapping when a status is clicked
- **Layout**: remove Tokens menu item from sidebar
- **Storage**: allow clearing habit chips to empty list