### PR TITLE
feat(telemetry): add OpenTelemetry tracing with Jaeger support

### DIFF
--- a/beaverhabits/app/crud.py
+++ b/beaverhabits/app/crud.py
@@ -6,6 +6,7 @@ from uuid import UUID
 from sqlalchemy import select
 
 from beaverhabits.logger import logger
+from beaverhabits.telemetry import traced
 
 from .db import (
     HabitListModel,
@@ -20,6 +21,7 @@ from .db import (
 get_async_session_context = contextlib.asynccontextmanager(get_async_session)
 
 
+@traced
 async def update_user_habit_list(user: User, data: dict) -> None:
     async with get_async_session_context() as session:
         assert data, "Habit list data cannot be empty"
@@ -46,6 +48,7 @@ async def update_user_habit_list(user: User, data: dict) -> None:
         logger.info(f"[CRUD] User {user.id} habit list updated")
 
 
+@traced
 async def get_user_habit_list(user: User) -> HabitListModel | None:
     async with get_async_session_context() as session:
         stmt = select(HabitListModel).where(HabitListModel.user_id == user.id)

--- a/beaverhabits/configs.py
+++ b/beaverhabits/configs.py
@@ -26,6 +26,10 @@ class Settings(BaseSettings):
     ENV: str = "dev"
     DEBUG: bool = False
 
+    # OpenTelemetry
+    OTEL_ENDPOINT: str = ""  # e.g. http://localhost:4317 (Jaeger OTLP gRPC)
+    OTEL_SERVICE_NAME: str = "beaverhabits"
+
     # SaaS
     APP_URL: str = ""
     SENTRY_DSN: str = ""

--- a/beaverhabits/frontend/components.py
+++ b/beaverhabits/frontend/components.py
@@ -19,6 +19,7 @@ from beaverhabits.core.backup import backup_to_telegram
 from beaverhabits.core.completions import CStatus, get_habit_date_completion
 from beaverhabits.core.note import update_square_style_context
 from beaverhabits.frontend import icons
+from beaverhabits.frontend.javascript import run_js
 from beaverhabits.frontend.javascript import force_checkbox_blur
 from beaverhabits.frontend.textarea import Textarea
 from beaverhabits.logger import logger
@@ -1057,7 +1058,7 @@ def tag_filter_component(active_habits: list[Habit], refresh: Callable):
         TagChip("Others", refresh=refresh)
 
         row.classes("tag-filter")
-        ui.run_javascript(
+        run_js(
             """
             const element = document.querySelector(".tag-filter");
         
@@ -1085,7 +1086,8 @@ def tag_filter_component(active_habits: list[Habit], refresh: Callable):
                     element.classList.remove("hidden");
                 }
             }, { passive: true  });
-            """
+            """,
+            name="tag_filter_scroll",
         )
 
 

--- a/beaverhabits/frontend/javascript.py
+++ b/beaverhabits/frontend/javascript.py
@@ -1,8 +1,27 @@
+from typing import Any
+
 from jinja2 import Environment
 from loguru import logger
 from nicegui import ui
 
 from beaverhabits.configs import settings
+from beaverhabits.telemetry import get_tracer
+
+_tracer = get_tracer(__name__)
+
+
+def run_js(code: str, *, name: str = "") -> None:
+    """Fire-and-forget: schedule JS in the browser, don't wait for result."""
+    span_name = f"js.{name}" if name else "js.run"
+    with _tracer.start_as_current_span(span_name):
+        ui.run_javascript(code)
+
+
+async def run_js_async(code: str, *, name: str = "") -> Any:
+    """Await JS execution and return the result (browser round-trip)."""
+    span_name = f"js.{name}" if name else "js.run_async"
+    with _tracer.start_as_current_span(span_name):
+        return await ui.run_javascript(code)
 
 PREVENT_CONTEXT_MENU = """\
 document.body.style.webkitTouchCallout='none';
@@ -79,31 +98,33 @@ PADDLE_JS = env.from_string(PADDLE_JS_TEMPLATE).render(
 
 def prevent_context_menu():
     logger.info("Run javascript to prevent context menu for iOS")
-    ui.run_javascript(PREVENT_CONTEXT_MENU)
+    run_js(PREVENT_CONTEXT_MENU, name="prevent_context_menu")
 
 
 def unhover_checkboxes():
-    ui.run_javascript(UNHOVER_CHECKBOXES)
+    run_js(UNHOVER_CHECKBOXES, name="unhover_checkboxes")
 
 
 def show_icons():
     logger.info("Showing icons in the menu")
-    ui.run_javascript(
+    run_js(
         """
         const icons = document.querySelectorAll('.theme-icon-lazy');
         icons.forEach(icon => {
             icon.classList.remove("invisible");
         });
-        """
+        """,
+        name="show_icons",
     )
 
 
 async def force_checkbox_blur():
     # Resolve ripple issue
     # https://github.com/quasarframework/quasar/blob/dev/ui/src/components/checkbox/QCheckbox.sass
-    await ui.run_javascript(
+    await run_js_async(
         """
        const checkboxes = document.querySelectorAll('.q-checkbox');
        checkboxes.forEach(checkbox => {checkbox.blur()});
-       """
+       """,
+        name="force_checkbox_blur",
     )

--- a/beaverhabits/frontend/tokens_page.py
+++ b/beaverhabits/frontend/tokens_page.py
@@ -2,6 +2,7 @@ from nicegui import ui
 
 from beaverhabits.app import crud
 from beaverhabits.app.db import User
+from beaverhabits.frontend.javascript import run_js
 from beaverhabits.frontend.layout import layout
 
 
@@ -34,8 +35,9 @@ async def tokens_page(user: User):
                             ui.button(
                                 "Copy",
                                 on_click=lambda: (
-                                    ui.run_javascript(
-                                        f"navigator.clipboard.writeText('{token}')"
+                                    run_js(
+                                        f"navigator.clipboard.writeText('{token}')",
+                                        name="copy_token",
                                     ),
                                     ui.notify("Copied to clipboard", color="positive"),
                                 ),

--- a/beaverhabits/main.py
+++ b/beaverhabits/main.py
@@ -12,6 +12,7 @@ from beaverhabits.routes.api import init_api_routes
 from beaverhabits.routes.metrics import init_metrics_routes
 from beaverhabits.routes.routes import init_gui_routes
 from beaverhabits.scheduler import daily_backup_task
+from beaverhabits.telemetry import init_telemetry
 
 logger.info("Starting BeaverHabits...")
 
@@ -44,6 +45,8 @@ async def lifespan(_: FastAPI):
 
 app = FastAPI(lifespan=lifespan)
 
+# OpenTelemetry – must be called before routes are added
+init_telemetry(app)
 
 # auth
 init_metrics_routes(app)

--- a/beaverhabits/plan/plan.py
+++ b/beaverhabits/plan/plan.py
@@ -3,6 +3,7 @@ import random
 
 from nicegui import app, ui
 
+from beaverhabits.frontend.javascript import run_js
 from beaverhabits.app import crud
 from beaverhabits.app.auth import user_from_token
 from beaverhabits.configs import settings
@@ -18,7 +19,7 @@ async def checkout():
     email = user.email if user else ""
     logger.info(f"Checkout email: {email}")
 
-    ui.run_javascript(f"openCheckout('{email}')")
+    run_js(f"openCheckout('{email}')", name="open_checkout")
 
 
 def redirect_pricing(msg: str):

--- a/beaverhabits/routes/routes.py
+++ b/beaverhabits/routes/routes.py
@@ -42,7 +42,7 @@ from beaverhabits.logger import logger
 from beaverhabits.routes.google_one_tap import google_one_tap_login
 from beaverhabits.storage import image_storage
 from beaverhabits.storage.meta import GUI_ROOT_PATH
-from beaverhabits.utils import dummy_days, fetch_user_dark_mode, get_user_today_date
+from beaverhabits.utils import dummy_days, fetch_user_dark_mode, get_user_today_date, register_on_connect_monitoring
 
 UNRESTRICTED_PAGE_ROUTES = ("/login", "/register")
 
@@ -119,6 +119,7 @@ async def demo_export() -> None:
 async def index_page(
     user: User = Depends(current_active_user),
 ) -> None:
+    register_on_connect_monitoring()
     days = await dummy_days(settings.INDEX_HABIT_DATE_COLUMNS)
     habit_list = await views.get_user_habit_list(user)
     index_page_ui(days, habit_list)
@@ -202,6 +203,12 @@ async def login_page(client: Client) -> Optional[RedirectResponse]:
     # Google One Tap Login
     google_one_tap_login()
 
+    # Register on_connect monitoring with current trace context (links js.* spans to /login)
+    register_on_connect_monitoring()
+
+    # Fetch user count during HTTP phase (warm DB connection, before WebSocket wait)
+    user_count = await get_user_count()
+
     async def try_login():
         if not email.value:
             ui.notify("Email is required", color="negative")
@@ -232,7 +239,7 @@ async def login_page(client: Client) -> Optional[RedirectResponse]:
         with ui.row().classes("gap-2 w-full items-center"):
             auth_forgot_password(email, views.forgot_password)
             ui.space()
-            if not await get_user_count() >= settings.MAX_USER_COUNT > 0:
+            if not user_count >= settings.MAX_USER_COUNT > 0:
                 auth_redirect("Create account", "/register")
 
 
@@ -364,7 +371,7 @@ def init_gui_routes(fastapi_app: FastAPI):
     oneyear = 365 * 24 * 60 * 60
     app.add_static_files("/statics", "statics", max_cache_age=oneyear)
     app.on_exception(handle_exception)
-    app.on_connect(fetch_user_dark_mode)
+    app.on_connect(fetch_user_dark_mode)  # fallback: no trace context, fires for all pages
     # app.on_connect(views.apply_theme_style)
 
     ui.run_with(

--- a/beaverhabits/telemetry.py
+++ b/beaverhabits/telemetry.py
@@ -1,0 +1,230 @@
+"""
+OpenTelemetry integration for BeaverHabits.
+
+Only active when opentelemetry-sdk and exporter packages are installed
+(i.e. the `fly` dependency group). Everywhere else this module is a no-op,
+so the rest of the codebase never needs to guard against ImportError itself.
+
+Usage
+-----
+    from beaverhabits.telemetry import traced
+
+    @traced
+    async def my_func():
+        ...
+
+    # Custom span name:
+    @traced("my_service.my_func")
+    async def my_func():
+        ...
+"""
+
+from __future__ import annotations
+
+import asyncio
+import functools
+from typing import TYPE_CHECKING, Callable, TypeVar
+
+from beaverhabits.logger import logger
+
+if TYPE_CHECKING:
+    from fastapi import FastAPI
+
+F = TypeVar("F", bound=Callable)
+
+
+# ---------------------------------------------------------------------------
+# No-op fallback – used when OTel packages are not installed
+# ---------------------------------------------------------------------------
+
+class _NoOpSpan:
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_):
+        pass
+
+    def set_attribute(self, *_):
+        pass
+
+
+class _NoOpTracer:
+    def start_as_current_span(self, name: str, **kwargs):
+        return _NoOpSpan()
+
+
+def _noop_instrument_app(_app: "FastAPI") -> None:
+    pass
+
+
+# ---------------------------------------------------------------------------
+# Real OTel implementation (only imported when packages are available)
+# ---------------------------------------------------------------------------
+
+def _build_real_setup():
+    try:
+        from opentelemetry import trace
+        from opentelemetry.sdk.resources import SERVICE_NAME, Resource
+        from opentelemetry.sdk.trace import TracerProvider
+        from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+        from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
+
+        def setup_telemetry(app: "FastAPI", endpoint: str, service_name: str) -> None:
+            resource = Resource(attributes={SERVICE_NAME: service_name})
+            exporter = OTLPSpanExporter(endpoint=endpoint, insecure=True)
+            provider = TracerProvider(resource=resource)
+            # SimpleSpanProcessor: export immediately (good for dev/debugging).
+            # Switch to BatchSpanProcessor in high-traffic production if needed.
+            provider.add_span_processor(SimpleSpanProcessor(exporter))
+            trace.set_tracer_provider(provider)
+            logger.info(f"OpenTelemetry tracer provider set up → {endpoint}")
+
+            # Auto-instrument FastAPI (HTTP spans)
+            # NiceGUI registers ALL page routes on its own `nicegui.app` instance,
+            # NOT on the main FastAPI app. We need to instrument both.
+            try:
+                from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
+                FastAPIInstrumentor.instrument_app(app)
+                logger.info("OTel: main FastAPI app instrumented")
+            except Exception as e:
+                logger.warning(f"OTel: FastAPI instrumentation failed: {e}")
+
+            try:
+                from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
+                from nicegui import app as nicegui_app
+                FastAPIInstrumentor.instrument_app(nicegui_app)
+                logger.info("OTel: NiceGUI app instrumented")
+            except ImportError:
+                pass  # NiceGUI not in this environment
+            except Exception as e:
+                logger.warning(f"OTel: NiceGUI instrumentation failed: {e}")
+
+            # Auto-instrument SQLAlchemy (SQL spans)
+            try:
+                from opentelemetry.instrumentation.sqlalchemy import SQLAlchemyInstrumentor
+                from beaverhabits.app.db import engine
+                SQLAlchemyInstrumentor().instrument(engine=engine.sync_engine)
+                logger.info("OTel: SQLAlchemy instrumented")
+            except Exception as e:
+                logger.warning(f"OTel: SQLAlchemy instrumentation failed: {e}")
+
+            # Auto-instrument httpx (outbound HTTP – backups, Paddle, etc.)
+            try:
+                from opentelemetry.instrumentation.httpx import HTTPXClientInstrumentor
+                HTTPXClientInstrumentor().instrument()
+                logger.info("OTel: HTTPX instrumented")
+            except Exception as e:
+                logger.warning(f"OTel: HTTPX instrumentation failed: {e}")
+
+        def get_tracer(name: str):
+            return trace.get_tracer(name)
+
+        return setup_telemetry, get_tracer
+
+    except ImportError:
+        return None, None
+
+
+_real_setup, _real_get_tracer = _build_real_setup()
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+def init_telemetry(app: "FastAPI") -> None:
+    """Call once at application startup (after the FastAPI app is created)."""
+    try:
+        from beaverhabits.configs import settings
+        endpoint = settings.OTEL_ENDPOINT
+        service_name = settings.OTEL_SERVICE_NAME
+
+        if not endpoint:
+            logger.debug("OTel: OTEL_ENDPOINT not set, tracing disabled")
+            return
+
+        if _real_setup is None:
+            logger.warning("OTel: packages not installed, tracing disabled")
+            return
+
+        _real_setup(app, endpoint, service_name)
+    except Exception as e:
+        logger.warning(f"OTel: init_telemetry failed, continuing without tracing: {e}")
+
+
+def get_tracer(name: str):
+    """
+    Return an OpenTelemetry Tracer, or a no-op tracer if OTel is unavailable.
+    Safe to call at module import time.
+    """
+    try:
+        if _real_get_tracer is not None:
+            return _real_get_tracer(name)
+    except Exception:
+        pass
+    return _NoOpTracer()
+
+
+def carry_trace_context(fn: F) -> F:
+    """
+    Capture the current OTel context and re-attach it when fn is called later
+    in a different asyncio Task (e.g. NiceGUI on_connect callbacks).
+
+    Usage – inside a page handler where the HTTP span is active:
+        client.on_connect(carry_trace_context(my_callback))
+    """
+    try:
+        if _real_get_tracer is None:
+            return fn
+        from opentelemetry import context as otel_context
+        ctx = otel_context.get_current()
+
+        @functools.wraps(fn)
+        async def wrapper(*args, **kwargs):
+            token = otel_context.attach(ctx)
+            try:
+                return await fn(*args, **kwargs)
+            finally:
+                otel_context.detach(token)
+        return wrapper  # type: ignore[return-value]
+    except Exception:
+        return fn
+
+
+def traced(_func: F | str | None = None, *, name: str | None = None) -> F:
+    """
+    Decorator that wraps a function (sync or async) in an OTel span.
+
+    Usage::
+
+        @traced
+        async def my_func(): ...
+
+        @traced("custom.span.name")
+        async def my_func(): ...
+    """
+    # Support @traced("name") — string passed as first positional arg
+    if isinstance(_func, str):
+        name = _func
+        _func = None
+    def decorator(func: F) -> F:
+        span_name = name or f"{func.__module__}.{func.__qualname__}"
+        tracer = get_tracer(func.__module__)
+
+        if asyncio.iscoroutinefunction(func):
+            @functools.wraps(func)
+            async def async_wrapper(*args, **kwargs):
+                with tracer.start_as_current_span(span_name):
+                    return await func(*args, **kwargs)
+            return async_wrapper  # type: ignore[return-value]
+        else:
+            @functools.wraps(func)
+            def sync_wrapper(*args, **kwargs):
+                with tracer.start_as_current_span(span_name):
+                    return func(*args, **kwargs)
+            return sync_wrapper  # type: ignore[return-value]
+
+    # Support both @traced and @traced("name")
+    if _func is not None:
+        return decorator(_func)
+    return decorator  # type: ignore[return-value]

--- a/beaverhabits/utils.py
+++ b/beaverhabits/utils.py
@@ -18,6 +18,9 @@ from cachetools import TTLCache
 from dateutil.relativedelta import relativedelta
 from fastapi import HTTPException
 from nicegui import app, ui
+
+from beaverhabits.frontend.javascript import run_js_async
+from beaverhabits.telemetry import carry_trace_context
 from psutil._common import bytes2human
 from starlette import status
 
@@ -45,8 +48,9 @@ def on_connect_task(fn):
 
 @on_connect_task
 async def fetch_user_timezone() -> None:
-    timezone = await ui.run_javascript(
-        "Intl.DateTimeFormat().resolvedOptions().timeZone"
+    timezone = await run_js_async(
+        "Intl.DateTimeFormat().resolvedOptions().timeZone",
+        name="fetch_timezone",
     )
     app.storage.user[TIME_ZONE_KEY] = timezone
     logger.info(f"User timezone from browser: {timezone}")
@@ -56,7 +60,7 @@ async def get_or_create_user_timezone() -> str:
     if timezone := app.storage.user.get(TIME_ZONE_KEY):
         return timezone
 
-    ui.context.client.on_connect(fetch_user_timezone)
+    ui.context.client.on_connect(carry_trace_context(fetch_user_timezone))
 
     return "UTC"
 
@@ -67,7 +71,7 @@ async def fetch_user_dark_mode() -> None:
         return
 
     try:
-        dark = await ui.run_javascript("Quasar.Dark.isActive")
+        dark = await run_js_async("Quasar.Dark.isActive", name="fetch_dark_mode")
         app.storage.user[DARK_MODE_KEY] = dark
         logger.info(f"User dark mode from browser: {dark}")
     except Exception as e:
@@ -83,6 +87,19 @@ def set_user_dark_mode(dark: bool) -> None:
         logger.info(f"User dark mode set to: {dark}")
     except Exception as e:
         logger.error(f"Error setting user dark mode: {e}")
+
+
+def register_on_connect_monitoring() -> None:
+    """
+    Register on_connect monitoring tasks for the current NiceGUI client,
+    carrying the current OTel trace context so js.* spans appear under the
+    page's HTTP span in Jaeger.
+
+    Call this from within a @ui.page handler (after the HTTP span is active).
+    The global app.on_connect(fetch_user_dark_mode) acts as a no-trace fallback
+    for pages that don't call this explicitly.
+    """
+    ui.context.client.on_connect(carry_trace_context(fetch_user_dark_mode))
 
 
 def get_user_dark_mode() -> bool | None:
@@ -133,7 +150,7 @@ def get_or_create_user_timezone_sync() -> str:
         logger.error(f"Error reading user timezone from storage: {e}")
 
     try:
-        ui.context.client.on_connect(fetch_user_timezone)
+        ui.context.client.on_connect(carry_trace_context(fetch_user_timezone))
     except Exception as e:
         logger.debug(f"Could not register fetch_user_timezone on connect: {e}")
 

--- a/beaverhabits/views.py
+++ b/beaverhabits/views.py
@@ -23,6 +23,7 @@ from beaverhabits.app.db import User
 from beaverhabits.configs import settings
 from beaverhabits.core.backup import backup_to_telegram
 from beaverhabits.frontend.components import redirect
+from beaverhabits.frontend.javascript import run_js
 from beaverhabits.logger import logger
 from beaverhabits.storage import get_user_dict_storage, session_storage
 from beaverhabits.storage.dict import DAY_MASK, DictHabitList
@@ -84,6 +85,7 @@ async def get_user_habit_list(user: User) -> HabitList:
     try:
         return await user_storage.get_user_habit_list(user)
     except Exception:
+        logger.exception("Failed to get habit list for user %s", user.email)
         raise HTTPException(
             status_code=404,
             detail="The habit list data may be broken or missing, please contact the administrator.",
@@ -337,11 +339,11 @@ async def set_user_cookies(user: User) -> None:
     
     async def set_cookies_task():
         # Set email cookie (add more properties as needed)
-        ui.run_javascript(f'document.cookie = "email={user.email}; path=/; SameSite=Lax";')
+        run_js(f'document.cookie = "email={user.email}; path=/; SameSite=Lax";', name="set_cookie_email")
 
         customer = await crud.get_user_identity(user.email)
         is_pro = customer.activated if customer else False
-        ui.run_javascript(f'document.cookie = "is_pro={str(is_pro).lower()}; path=/; SameSite=Lax";')
+        run_js(f'document.cookie = "is_pro={str(is_pro).lower()}; path=/; SameSite=Lax";', name="set_cookie_is_pro")
     
     ui.timer(0.1, set_cookies_task, once=True)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,12 @@ fly = [
     "highlight-io>=0.9.3",
     # "guppy3>=3.1.5",
     "memray>=1.17.2",
+    # OpenTelemetry
+    "opentelemetry-sdk>=1.25.0",
+    "opentelemetry-instrumentation-fastapi>=0.46b0",
+    "opentelemetry-instrumentation-sqlalchemy>=0.46b0",
+    "opentelemetry-instrumentation-httpx>=0.46b0",
+    "opentelemetry-exporter-otlp-proto-grpc>=1.25.0",
 ]
 
 [project.scripts]

--- a/uv.lock
+++ b/uv.lock
@@ -225,6 +225,15 @@ wheels = [
 ]
 
 [[package]]
+name = "asgiref"
+version = "3.11.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/63/40/f03da1264ae8f7cfdbf9146542e5e7e8100a4c66ab48e791df9a03d3f6c0/asgiref-3.11.1.tar.gz", hash = "sha256:5f184dc43b7e763efe848065441eac62229c9f7b0475f41f80e207a114eda4ce", size = 38550, upload-time = "2026-02-03T13:30:14.33Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5c/0a/a72d10ed65068e115044937873362e6e32fab1b7dce0046aeb224682c989/asgiref-3.11.1-py3-none-any.whl", hash = "sha256:e8667a091e69529631969fd45dc268fa79b99c92c5fcdda727757e52146ec133", size = 24345, upload-time = "2026-02-03T13:30:13.039Z" },
+]
+
+[[package]]
 name = "asttokens"
 version = "3.0.1"
 source = { registry = "https://pypi.org/simple" }
@@ -399,6 +408,11 @@ dev = [
 fly = [
     { name = "highlight-io" },
     { name = "memray" },
+    { name = "opentelemetry-exporter-otlp-proto-grpc" },
+    { name = "opentelemetry-instrumentation-fastapi" },
+    { name = "opentelemetry-instrumentation-httpx" },
+    { name = "opentelemetry-instrumentation-sqlalchemy" },
+    { name = "opentelemetry-sdk" },
     { name = "paddle-python-sdk" },
     { name = "sentry-sdk", extra = ["fastapi"] },
 ]
@@ -443,6 +457,11 @@ dev = [
 fly = [
     { name = "highlight-io", specifier = ">=0.9.3" },
     { name = "memray", specifier = ">=1.17.2" },
+    { name = "opentelemetry-exporter-otlp-proto-grpc", specifier = ">=1.25.0" },
+    { name = "opentelemetry-instrumentation-fastapi", specifier = ">=0.46b0" },
+    { name = "opentelemetry-instrumentation-httpx", specifier = ">=0.46b0" },
+    { name = "opentelemetry-instrumentation-sqlalchemy", specifier = ">=0.46b0" },
+    { name = "opentelemetry-sdk", specifier = ">=1.25.0" },
     { name = "paddle-python-sdk", specifier = ">=1.6.0" },
     { name = "sentry-sdk", extras = ["fastapi"], specifier = ">=2.15.0,<3.0.0" },
 ]
@@ -986,6 +1005,47 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/f3/fd/d05a4b7acd0154ed758797f0a43b4c0962a843bedfe980115e842c5b2d08/greenlet-3.3.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:1fb39a11ee2e4d94be9a76671482be9398560955c9e568550de0224e41104727", size = 1618857, upload-time = "2026-02-20T20:49:37.309Z" },
     { url = "https://files.pythonhosted.org/packages/6f/e1/50ee92a5db521de8f35075b5eff060dd43d39ebd46c2181a2042f7070385/greenlet-3.3.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:20154044d9085151bc309e7689d6f7ba10027f8f5a8c0676ad398b951913d89e", size = 1680010, upload-time = "2026-02-20T20:21:13.427Z" },
     { url = "https://files.pythonhosted.org/packages/29/4b/45d90626aef8e65336bed690106d1382f7a43665e2249017e9527df8823b/greenlet-3.3.2-cp314-cp314t-win_amd64.whl", hash = "sha256:c04c5e06ec3e022cbfe2cd4a846e1d4e50087444f875ff6d2c2ad8445495cf1a", size = 237086, upload-time = "2026-02-20T20:20:45.786Z" },
+]
+
+[[package]]
+name = "grpcio"
+version = "1.78.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/8a/3d098f35c143a89520e568e6539cc098fcd294495910e359889ce8741c84/grpcio-1.78.0.tar.gz", hash = "sha256:7382b95189546f375c174f53a5fa873cef91c4b8005faa05cc5b3beea9c4f1c5", size = 12852416, upload-time = "2026-02-06T09:57:18.093Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4e/f4/7384ed0178203d6074446b3c4f46c90a22ddf7ae0b3aee521627f54cfc2a/grpcio-1.78.0-cp312-cp312-linux_armv7l.whl", hash = "sha256:f9ab915a267fc47c7e88c387a3a28325b58c898e23d4995f765728f4e3dedb97", size = 5913985, upload-time = "2026-02-06T09:55:26.832Z" },
+    { url = "https://files.pythonhosted.org/packages/81/ed/be1caa25f06594463f685b3790b320f18aea49b33166f4141bfdc2bfb236/grpcio-1.78.0-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:3f8904a8165ab21e07e58bf3e30a73f4dffc7a1e0dbc32d51c61b5360d26f43e", size = 11811853, upload-time = "2026-02-06T09:55:29.224Z" },
+    { url = "https://files.pythonhosted.org/packages/24/a7/f06d151afc4e64b7e3cc3e872d331d011c279aaab02831e40a81c691fb65/grpcio-1.78.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:859b13906ce098c0b493af92142ad051bf64c7870fa58a123911c88606714996", size = 6475766, upload-time = "2026-02-06T09:55:31.825Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/a8/4482922da832ec0082d0f2cc3a10976d84a7424707f25780b82814aafc0a/grpcio-1.78.0-cp312-cp312-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:b2342d87af32790f934a79c3112641e7b27d63c261b8b4395350dad43eff1dc7", size = 7170027, upload-time = "2026-02-06T09:55:34.7Z" },
+    { url = "https://files.pythonhosted.org/packages/54/bf/f4a3b9693e35d25b24b0b39fa46d7d8a3c439e0a3036c3451764678fec20/grpcio-1.78.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:12a771591ae40bc65ba67048fa52ef4f0e6db8279e595fd349f9dfddeef571f9", size = 6690766, upload-time = "2026-02-06T09:55:36.902Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/b9/521875265cc99fe5ad4c5a17010018085cae2810a928bf15ebe7d8bcd9cc/grpcio-1.78.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:185dea0d5260cbb2d224c507bf2a5444d5abbb1fa3594c1ed7e4c709d5eb8383", size = 7266161, upload-time = "2026-02-06T09:55:39.824Z" },
+    { url = "https://files.pythonhosted.org/packages/05/86/296a82844fd40a4ad4a95f100b55044b4f817dece732bf686aea1a284147/grpcio-1.78.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:51b13f9aed9d59ee389ad666b8c2214cc87b5de258fa712f9ab05f922e3896c6", size = 8253303, upload-time = "2026-02-06T09:55:42.353Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/e4/ea3c0caf5468537f27ad5aab92b681ed7cc0ef5f8c9196d3fd42c8c2286b/grpcio-1.78.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:fd5f135b1bd58ab088930b3c613455796dfa0393626a6972663ccdda5b4ac6ce", size = 7698222, upload-time = "2026-02-06T09:55:44.629Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/47/7f05f81e4bb6b831e93271fb12fd52ba7b319b5402cbc101d588f435df00/grpcio-1.78.0-cp312-cp312-win32.whl", hash = "sha256:94309f498bcc07e5a7d16089ab984d42ad96af1d94b5a4eb966a266d9fcabf68", size = 4066123, upload-time = "2026-02-06T09:55:47.644Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/e7/d6914822c88aa2974dbbd10903d801a28a19ce9cd8bad7e694cbbcf61528/grpcio-1.78.0-cp312-cp312-win_amd64.whl", hash = "sha256:9566fe4ababbb2610c39190791e5b829869351d14369603702e890ef3ad2d06e", size = 4797657, upload-time = "2026-02-06T09:55:49.86Z" },
+    { url = "https://files.pythonhosted.org/packages/05/a9/8f75894993895f361ed8636cd9237f4ab39ef87fd30db17467235ed1c045/grpcio-1.78.0-cp313-cp313-linux_armv7l.whl", hash = "sha256:ce3a90455492bf8bfa38e56fbbe1dbd4f872a3d8eeaf7337dc3b1c8aa28c271b", size = 5920143, upload-time = "2026-02-06T09:55:52.035Z" },
+    { url = "https://files.pythonhosted.org/packages/55/06/0b78408e938ac424100100fd081189451b472236e8a3a1f6500390dc4954/grpcio-1.78.0-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:2bf5e2e163b356978b23652c4818ce4759d40f4712ee9ec5a83c4be6f8c23a3a", size = 11803926, upload-time = "2026-02-06T09:55:55.494Z" },
+    { url = "https://files.pythonhosted.org/packages/88/93/b59fe7832ff6ae3c78b813ea43dac60e295fa03606d14d89d2e0ec29f4f3/grpcio-1.78.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8f2ac84905d12918e4e55a16da17939eb63e433dc11b677267c35568aa63fc84", size = 6478628, upload-time = "2026-02-06T09:55:58.533Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/df/e67e3734527f9926b7d9c0dde6cd998d1d26850c3ed8eeec81297967ac67/grpcio-1.78.0-cp313-cp313-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:b58f37edab4a3881bc6c9bca52670610e0c9ca14e2ea3cf9debf185b870457fb", size = 7173574, upload-time = "2026-02-06T09:56:01.786Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/62/cc03fffb07bfba982a9ec097b164e8835546980aec25ecfa5f9c1a47e022/grpcio-1.78.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:735e38e176a88ce41840c21bb49098ab66177c64c82426e24e0082500cc68af5", size = 6692639, upload-time = "2026-02-06T09:56:04.529Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/9a/289c32e301b85bdb67d7ec68b752155e674ee3ba2173a1858f118e399ef3/grpcio-1.78.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:2045397e63a7a0ee7957c25f7dbb36ddc110e0cfb418403d110c0a7a68a844e9", size = 7268838, upload-time = "2026-02-06T09:56:08.397Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/79/1be93f32add280461fa4773880196572563e9c8510861ac2da0ea0f892b6/grpcio-1.78.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:a9f136fbafe7ccf4ac7e8e0c28b31066e810be52d6e344ef954a3a70234e1702", size = 8251878, upload-time = "2026-02-06T09:56:10.914Z" },
+    { url = "https://files.pythonhosted.org/packages/65/65/793f8e95296ab92e4164593674ae6291b204bb5f67f9d4a711489cd30ffa/grpcio-1.78.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:748b6138585379c737adc08aeffd21222abbda1a86a0dca2a39682feb9196c20", size = 7695412, upload-time = "2026-02-06T09:56:13.593Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/9f/1e233fe697ecc82845942c2822ed06bb522e70d6771c28d5528e4c50f6a4/grpcio-1.78.0-cp313-cp313-win32.whl", hash = "sha256:271c73e6e5676afe4fc52907686670c7cea22ab2310b76a59b678403ed40d670", size = 4064899, upload-time = "2026-02-06T09:56:15.601Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/27/d86b89e36de8a951501fb06a0f38df19853210f341d0b28f83f4aa0ffa08/grpcio-1.78.0-cp313-cp313-win_amd64.whl", hash = "sha256:f2d4e43ee362adfc05994ed479334d5a451ab7bc3f3fee1b796b8ca66895acb4", size = 4797393, upload-time = "2026-02-06T09:56:17.882Z" },
+    { url = "https://files.pythonhosted.org/packages/29/f2/b56e43e3c968bfe822fa6ce5bca10d5c723aa40875b48791ce1029bb78c7/grpcio-1.78.0-cp314-cp314-linux_armv7l.whl", hash = "sha256:e87cbc002b6f440482b3519e36e1313eb5443e9e9e73d6a52d43bd2004fcfd8e", size = 5920591, upload-time = "2026-02-06T09:56:20.758Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/81/1f3b65bd30c334167bfa8b0d23300a44e2725ce39bba5b76a2460d85f745/grpcio-1.78.0-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:c41bc64626db62e72afec66b0c8a0da76491510015417c127bfc53b2fe6d7f7f", size = 11813685, upload-time = "2026-02-06T09:56:24.315Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/1c/bbe2f8216a5bd3036119c544d63c2e592bdf4a8ec6e4a1867592f4586b26/grpcio-1.78.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8dfffba826efcf366b1e3ccc37e67afe676f290e13a3b48d31a46739f80a8724", size = 6487803, upload-time = "2026-02-06T09:56:27.367Z" },
+    { url = "https://files.pythonhosted.org/packages/16/5c/a6b2419723ea7ddce6308259a55e8e7593d88464ce8db9f4aa857aba96fa/grpcio-1.78.0-cp314-cp314-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:74be1268d1439eaaf552c698cdb11cd594f0c49295ae6bb72c34ee31abbe611b", size = 7173206, upload-time = "2026-02-06T09:56:29.876Z" },
+    { url = "https://files.pythonhosted.org/packages/df/1e/b8801345629a415ea7e26c83d75eb5dbe91b07ffe5210cc517348a8d4218/grpcio-1.78.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:be63c88b32e6c0f1429f1398ca5c09bc64b0d80950c8bb7807d7d7fb36fb84c7", size = 6693826, upload-time = "2026-02-06T09:56:32.305Z" },
+    { url = "https://files.pythonhosted.org/packages/34/84/0de28eac0377742679a510784f049738a80424b17287739fc47d63c2439e/grpcio-1.78.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:3c586ac70e855c721bda8f548d38c3ca66ac791dc49b66a8281a1f99db85e452", size = 7277897, upload-time = "2026-02-06T09:56:34.915Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/9c/ad8685cfe20559a9edb66f735afdcb2b7d3de69b13666fdfc542e1916ebd/grpcio-1.78.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:35eb275bf1751d2ffbd8f57cdbc46058e857cf3971041521b78b7db94bdaf127", size = 8252404, upload-time = "2026-02-06T09:56:37.553Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/05/33a7a4985586f27e1de4803887c417ec7ced145ebd069bc38a9607059e2b/grpcio-1.78.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:207db540302c884b8848036b80db352a832b99dfdf41db1eb554c2c2c7800f65", size = 7696837, upload-time = "2026-02-06T09:56:40.173Z" },
+    { url = "https://files.pythonhosted.org/packages/73/77/7382241caf88729b106e49e7d18e3116216c778e6a7e833826eb96de22f7/grpcio-1.78.0-cp314-cp314-win32.whl", hash = "sha256:57bab6deef2f4f1ca76cc04565df38dc5713ae6c17de690721bdf30cb1e0545c", size = 4142439, upload-time = "2026-02-06T09:56:43.258Z" },
+    { url = "https://files.pythonhosted.org/packages/48/b2/b096ccce418882fbfda4f7496f9357aaa9a5af1896a9a7f60d9f2b275a06/grpcio-1.78.0-cp314-cp314-win_amd64.whl", hash = "sha256:dce09d6116df20a96acfdbf85e4866258c3758180e8c49845d6ba8248b6d0bbb", size = 4929852, upload-time = "2026-02-06T09:56:45.885Z" },
 ]
 
 [[package]]
@@ -1642,6 +1702,24 @@ wheels = [
 ]
 
 [[package]]
+name = "opentelemetry-exporter-otlp-proto-grpc"
+version = "1.28.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "deprecated" },
+    { name = "googleapis-common-protos" },
+    { name = "grpcio" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-exporter-otlp-proto-common" },
+    { name = "opentelemetry-proto" },
+    { name = "opentelemetry-sdk" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f7/4c/b5374467e97f2b290611de746d0e6cab3a07aec865d6b99d11535cd60059/opentelemetry_exporter_otlp_proto_grpc-1.28.2.tar.gz", hash = "sha256:07c10378380bbb01a7f621a5ce833fc1fab816e971140cd3ea1cd587840bc0e6", size = 26227, upload-time = "2024-11-18T18:29:47.576Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dd/7e/6af5a7de87988cfc951db86f7fd0ecaabc20bc112fd9cfe06b8a01f11400/opentelemetry_exporter_otlp_proto_grpc-1.28.2-py3-none-any.whl", hash = "sha256:6083d9300863aab35bfce7c172d5fc1007686e6f8dff366eae460cd9a21592e2", size = 18518, upload-time = "2024-11-18T18:29:23.71Z" },
+]
+
+[[package]]
 name = "opentelemetry-exporter-otlp-proto-http"
 version = "1.28.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1687,6 +1765,22 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/40/0a/cba0a6ac1832e3002158b5a9451268aebfe0150c7b8355068d1f2cea148b/opentelemetry_instrumentation_anthropic-0.33.12.tar.gz", hash = "sha256:0bc1fd9d4cf2feec4fe9f80c0bdfcbfab33ed9cf0edea850b6c198a8679b01ff", size = 8711, upload-time = "2024-11-13T20:27:52.005Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ba/46/ba2dc8d18b04acae3d34facd8fe1e5e0cdc9fe64292d45eca9d1d4a8a298/opentelemetry_instrumentation_anthropic-0.33.12-py3-none-any.whl", hash = "sha256:b31618d12a429045db14ed982a142a25df0f0f1dbf03d756e8d597f25b9a053d", size = 11024, upload-time = "2024-11-13T20:27:14.622Z" },
+]
+
+[[package]]
+name = "opentelemetry-instrumentation-asgi"
+version = "0.49b2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "asgiref" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-instrumentation" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "opentelemetry-util-http" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/84/42/079079bd7c0423bfab987a6457e34468b6ddccf501d3c91d2795c200d65d/opentelemetry_instrumentation_asgi-0.49b2.tar.gz", hash = "sha256:2af5faf062878330714efe700127b837038c4d9d3b70b451ab2424d5076d6c1c", size = 24106, upload-time = "2024-11-18T18:39:51.116Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3f/82/06a56e786de3ea0ef4703ed313d9d8395fb4bc9ae740cc71415178ae8bff/opentelemetry_instrumentation_asgi-0.49b2-py3-none-any.whl", hash = "sha256:c8ede13ed781402458a800411cb7ec16a25386dc21de8e5b9a568b386a1dc5f4", size = 16305, upload-time = "2024-11-18T18:38:39.722Z" },
 ]
 
 [[package]]
@@ -1779,6 +1873,22 @@ wheels = [
 ]
 
 [[package]]
+name = "opentelemetry-instrumentation-fastapi"
+version = "0.49b2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-instrumentation" },
+    { name = "opentelemetry-instrumentation-asgi" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "opentelemetry-util-http" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/87/ed/a1275d5aac63edfad0afb012d2d5917412f09ac5f773c86b465b2b0d2549/opentelemetry_instrumentation_fastapi-0.49b2.tar.gz", hash = "sha256:3aa81ed7acf6aa5236d96e90a1218c5e84a9c0dce8fa63bf34ceee6218354b63", size = 19217, upload-time = "2024-11-18T18:40:04.125Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d3/a9/ef2678c16caf5dc2f84628bfafdbc90139e3c78d9017afd07fbd51b1eeef/opentelemetry_instrumentation_fastapi-0.49b2-py3-none-any.whl", hash = "sha256:c66331d05bf806d7ca4f9579c1db7383aad31a9f6665dbaa2b7c9a4c1e830892", size = 12082, upload-time = "2024-11-18T18:38:58.133Z" },
+]
+
+[[package]]
 name = "opentelemetry-instrumentation-haystack"
 version = "0.33.12"
 source = { registry = "https://pypi.org/simple" }
@@ -1791,6 +1901,22 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/9c/06/067e4b2db2bc29d0a7e3a6cc8676d5f1971b0ecbaf7e5fa0c1e478e092af/opentelemetry_instrumentation_haystack-0.33.12.tar.gz", hash = "sha256:3d45df14aff1f2321066e55ecce632653d67c36249d3eaccbefa189f0daaba05", size = 4663, upload-time = "2024-11-13T20:28:01.551Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/dc/ba/b8872dce7eb67bd6589d4cccfc97554851dad719067b24c7697a5ffef69a/opentelemetry_instrumentation_haystack-0.33.12-py3-none-any.whl", hash = "sha256:d2a3041a58e1027d8728e1a24430f7b01e8c27e9c04c22fa4204c590b12a95f6", size = 7513, upload-time = "2024-11-13T20:27:24.671Z" },
+]
+
+[[package]]
+name = "opentelemetry-instrumentation-httpx"
+version = "0.49b2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-instrumentation" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "opentelemetry-util-http" },
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b2/76/ecd15d1ebd587b638d032ec83b0a8eb08467bec4e679a2421c3a9cc13ea0/opentelemetry_instrumentation_httpx-0.49b2.tar.gz", hash = "sha256:4330f56b0ad382843a1e8fe6179d20c2d2be3ee78e60b9f01ee892b1600de44f", size = 17762, upload-time = "2024-11-18T18:40:07.211Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3d/fe/ea1e501b8415cb938035b8d707dcd952563bf0d99373728895233be0c15c/opentelemetry_instrumentation_httpx-0.49b2-py3-none-any.whl", hash = "sha256:08111e6c8d11495dee7ef2243bc2e9acc09c16be8c6f4dd32f939f2b08f30af5", size = 14093, upload-time = "2024-11-18T18:39:02.312Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
- Add telemetry.py with SDK init, NoOp fallback, @traced decorator,
  and carry_trace_context for async callback propagation
- Instrument both main FastAPI app and NiceGUI sub-app
- Add @traced to crud.get_user_habit_list and update_user_habit_list
- Unify all ui.run_javascript calls through run_js/run_js_async
  with named spans for profiling
- Propagate OTel context into NiceGUI on_connect callbacks so
  js.* spans appear under the page HTTP span in Jaeger
- Fix login_page: move get_user_count() before client.connected()
  to avoid cold-connection penalty after WebSocket wait
- Add OTEL_ENDPOINT and OTEL_SERVICE_NAME config options
- Add OTel packages to fly dependency group
- Add docker-compose.jaeger.yml for local Jaeger setup
